### PR TITLE
docs: clarify return statement grammar

### DIFF
--- a/src/parser/README.md
+++ b/src/parser/README.md
@@ -17,10 +17,10 @@ IfExpression ::= "if" "(" Expression ")" BlockStatement | "if" "(" Expression ")
 
 ## 基本要素
 
-LetStatement ::= "let" Identifier "=" Expression  
-ReturnStatement::= "return" Expression
-PrefixExpression ::= PrefixOperator Expression  
-InfixExpression ::= Expression InfixOperator Expression  
+LetStatement ::= "let" Identifier "=" Expression
+ReturnStatement ::= "return" Expression?
+PrefixExpression ::= PrefixOperator Expression
+InfixExpression ::= Expression InfixOperator Expression
 CallExpression ::= Expression "(" (Expression ("," Expression)*)? ")"  
 PrefixOperator ::= "!" | "-" | "+"    
 InfixOperator ::= "+" | "-" | "*" | "/" | ">" | "<" | "==" | "!="


### PR DESCRIPTION
## Summary
- document optional expression for return statements in parser README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bc140174c83308f01a1ddf4e1038e